### PR TITLE
Fix s3 url to fit static website hosting

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -95,7 +95,7 @@ def lambda_handler(event, context):
     fg.link(href=feed.feed.link, rel='alternate')
     fg.subtitle(feed.feed.description)
 
-    ENTRY_URL = "https://s3.amazonaws.com/{bucket}/{filename}"
+    ENTRY_URL = "http://{bucket}.s3-website.{region}.amazonaws.com/{filename}"
 
     for entry in get_entries(feed):
         filename = "%s.mp3" % entry['id']
@@ -103,7 +103,7 @@ def lambda_handler(event, context):
         fe.id(entry['id'])
         fe.title(entry['title'])
         fe.published(entry['published'])
-        entry_url = ENTRY_URL.format(bucket=bucket_name, filename=filename)
+        entry_url = ENTRY_URL.format(bucket=bucket_name, filename=filename, region=os.environ["AWS_REGION"])
         fe.enclosure(entry_url, 0, 'audio/mpeg')
         if filename in files:
             logging.info('Article "%s" with id %s already exist, skipping.'


### PR DESCRIPTION
If S3 static website is enabled, entry URL is of the form
  http://{bucket}.s3-website-{AWS-region}.amazonaws.com/{filename}
but the current URL is of the form
  https://s3.amazonaws.com/{bucket}/{filename}

If you `GET` S3 resources with the current URL schema, you'll encounter error messages as follows:

> The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.

I changed entry URLs to fit with S3 static website styles.

This PR assumes that Lambda and S3 are in the same region.