### PR TITLE
Generating an hash of the entry if when it is an URL

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -18,6 +18,7 @@ from feedgen.feed import FeedGenerator
 from bs4 import BeautifulSoup
 import datetime
 import dateutil.parser
+import hashlib
 
 MAX_TPS = 10
 MAX_CONCURENT_CONNECTIONS = 20
@@ -52,6 +53,9 @@ def split_content_by_dot(soup, max_len):
 def get_entries(feed):
     NEW_POST = u"""New post, author {author}, title {title} {content}"""
     for entry in feed.entries:
+        if "http" in entry.id:
+            nid = hashlib.md5(str(entry.id))
+            entry.id = nid.hexdigest()
         entry_content = entry.content[0].value
         soup = BeautifulSoup(entry_content, 'html.parser')
         chunks = split_content_by_dot(soup, REQUEST_LIMIT-len(NEW_POST))


### PR DESCRIPTION
Often the RSS feed return the URL of the post as the post id, and it's break the generation of the Object to upload in the S3 Bucket.